### PR TITLE
Remove Perl version duplication in Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: perl
-perl:
-    - "5.24"
-    - "blead"
 
 matrix:
     include:
         - perl: "5.24"
           env: COVERAGE=1
+        - perl: "blead"
     allow_failures:
         - perl: "blead"
 


### PR DESCRIPTION
It turned out with the previous configuration that perl 5.24 would run
twice: one time each with and without coverage tests on.  It's only
really necessary to build and test with 5.24 the once, hence it's only
necessary to specify the Perl versions to use within the 'matrix'
section's 'include' block.