### PR TITLE
Use MySQL version 5.7 in Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: required
 language: perl
 perl:
     - "5.24"
@@ -6,11 +7,12 @@ perl:
 matrix:
     include:
         - perl: "5.24"
-          env: COVERAGE=1
+          env: COVERAGE=1 MYSQL_VERSION=5.7
     allow_failures:
         - perl: "blead"
 
 before_install:
+    - bash author/travis-install-mysql.sh
     - git clone git://github.com/travis-perl/helpers ~/travis-perl-helpers
     - source ~/travis-perl-helpers/init
     - build-perl

--- a/author/travis-install-mysql.sh
+++ b/author/travis-install-mysql.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -ex
+
+if [ x"$MYSQL_VERSION" != "x" ]
+then
+    sudo service mysql stop;
+    sudo aptitude purge -y mysql-server libmysqlclient-dev mysql-server-5.6 mysql-common-5.6 mysql-client-5.6 libmysqlclient18 mysql-client-core-5.6 mysql-server-core-5.6 libdbd-mysql-perl mysql-common
+    sudo apt-key adv --keyserver pgp.mit.edu --recv-keys 5072E1F5
+    . /etc/lsb-release  # sets the env var DISTRIB_CODENAME
+    sudo add-apt-repository "deb http://repo.mysql.com/apt/ubuntu/ $DISTRIB_CODENAME mysql-$MYSQL_VERSION"
+    sudo apt-get update
+    sudo DEBIAN_FRONTEND=noninteractive apt-get -q --yes --fix-broken --allow-unauthenticated --option DPkg::Options::=--force-confnew install mysql-server libmysqlclient-dev
+    sudo mysql_upgrade -u root --password='' --force
+    sudo service mysql restart
+fi
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
... since this version supports the JSON field and hence would allow the
tests to pass.  Also, reinstalling MySQL solves a strange error which
looks like it's only associated with Travis and the MySQL version that
comes preinstalled on a build VM: when Test::mysqld tries to initialise,
it uses `mysql_install_db` internally, which for some reason tries to
find `my-default.cnf`, which doesn't exist, hence an error is thrown and
the tests fail.  If one installs one's own MySQL version, then this
issue disappears.

Note that this patch requires #16 in order for the tests to pass on Travis.  The inspiration for the current solution came from how Test::mysqld installs MySQL (and different versions thereof).  If you're happy with this patch, then I can extend the install script to handle more MySQL versions.