### PR TITLE
Restrict tests to correct MySQL version

### DIFF
--- a/t/process_reports.t
+++ b/t/process_reports.t
@@ -19,6 +19,7 @@ use CPAN::Testers::Backend::Base 'Test';
 use Mock::MonkeyPatch;
 use CPAN::Testers::Schema;
 use CPAN::Testers::Backend::ProcessReports;
+use DBI;
 eval { require Test::mysqld } or plan skip_all => 'Requires Test::mysqld';
 
 my $mysqld = Test::mysqld->new(
@@ -43,7 +44,6 @@ CREATE TABLE `page_requests` (
   `id` int(10) unsigned DEFAULT '0'
 )});
 
-use DBI;
 my $metabase_dbh = DBI->connect( 'dbi:SQLite::memory:', undef, undef, { RaiseError => 1 } );
 $metabase_dbh->do(q{
     CREATE TABLE `metabase` (


### PR DESCRIPTION
These changes ensure that the tests requiring MySQL only run if a MySQL or MariaDB version are sufficiently recent so as to support the JSON field.  This PR thus addresses issue #8.